### PR TITLE
Am I missing something with these pointers?

### DIFF
--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -145,7 +145,7 @@ func (addr I2PAddr) ToBytes() ([]byte, error) {
 
 // Turns an I2P address to a byte array. The inverse of NewI2PAddrFromBytes().
 func (addr I2PAddr) Bytes() ([]byte) {
-    b, _ addr.ToBytes()
+    b, _ := addr.ToBytes()
 	return b
 }
 

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -143,9 +143,8 @@ func (addr I2PAddr) ToBytes() ([]byte, error) {
 	return buf, nil
 }
 
-// Turns an I2P address to a byte array. The inverse of NewI2PAddrFromBytes().
-func (addr I2PAddr) Bytes() ([]byte) {
-    b, _ := addr.ToBytes()
+func (addr I2PAddr) Bytes() []byte {
+	b, _ := addr.ToBytes()
 	return b
 }
 

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -116,7 +116,7 @@ func (a I2PAddr) String() string {
 }
 
 // Returns "I2P"
-func (a *I2PAddr) Network() string {
+func (a I2PAddr) Network() string {
 	return "I2P"
 }
 

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -143,6 +143,12 @@ func (addr I2PAddr) ToBytes() ([]byte, error) {
 	return buf, nil
 }
 
+// Turns an I2P address to a byte array. The inverse of NewI2PAddrFromBytes().
+func (addr I2PAddr) Bytes() ([]byte) {
+    b, _ addr.ToBytes()
+	return b
+}
+
 // Returns the *.b32.i2p address of the I2P address. It is supposed to be a
 // somewhat human-manageable 64 character long pseudo-domain name equivalent of
 // the 516+ characters long default base64-address (the I2PAddr format). It is

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -48,24 +48,6 @@ func StoreKeysIncompat(k I2PKeys, w io.Writer) (err error) {
 	return
 }
 
-// load keys from non standard format
-func CryptLoadKeysIncompat(r io.Reader) (k I2PKeys, err error) {
-	var buff bytes.Buffer
-	_, err = io.Copy(&buff, r)
-	if err == nil {
-		parts := strings.Split(buff.String(), "\n")
-		k = I2PKeys{I2PAddr(parts[0]), parts[1]}
-	}
-	return
-}
-
-// store keys in non standard format
-func CryptStoreKeysIncompat(k I2PKeys, w io.Writer) (err error) {
-    s := k.addr.Base64()+"\n"+k.both
-	_, err = io.WriteString(w, s)
-	return
-}
-
 // Returns the public keys of the I2PKeys.
 func (k I2PKeys) Addr() I2PAddr {
 	return k.addr

--- a/I2PAddr.go
+++ b/I2PAddr.go
@@ -48,6 +48,24 @@ func StoreKeysIncompat(k I2PKeys, w io.Writer) (err error) {
 	return
 }
 
+// load keys from non standard format
+func CryptLoadKeysIncompat(r io.Reader) (k I2PKeys, err error) {
+	var buff bytes.Buffer
+	_, err = io.Copy(&buff, r)
+	if err == nil {
+		parts := strings.Split(buff.String(), "\n")
+		k = I2PKeys{I2PAddr(parts[0]), parts[1]}
+	}
+	return
+}
+
+// store keys in non standard format
+func CryptStoreKeysIncompat(k I2PKeys, w io.Writer) (err error) {
+    s := k.addr.Base64()+"\n"+k.both
+	_, err = io.WriteString(w, s)
+	return
+}
+
 // Returns the public keys of the I2PKeys.
 func (k I2PKeys) Addr() I2PAddr {
 	return k.addr
@@ -98,7 +116,7 @@ func (a I2PAddr) String() string {
 }
 
 // Returns "I2P"
-func (a I2PAddr) Network() string {
+func (a *I2PAddr) Network() string {
 	return "I2P"
 }
 

--- a/SAMConn.go
+++ b/SAMConn.go
@@ -29,21 +29,21 @@ func (sc SAMConn) Close() error {
 	return sc.conn.Close()
 }
 
-func (sc *SAMConn) LocalAddr() net.Addr {
+func (sc SAMConn) LocalAddr() net.Addr {
 	return sc.localAddr()
 }
 
 // Implements net.Conn
-func (sc *SAMConn) localAddr() I2PAddr {
+func (sc SAMConn) localAddr() I2PAddr {
 	return sc.laddr
 }
 
-func (sc *SAMConn) RemoteAddr() net.Addr {
+func (sc SAMConn) RemoteAddr() net.Addr {
 	return sc.remoteAddr()
 }
 
 // Implements net.Conn
-func (sc *SAMConn) remoteAddr() I2PAddr {
+func (sc SAMConn) remoteAddr() I2PAddr {
 	return sc.raddr
 }
 
@@ -53,11 +53,11 @@ func (sc SAMConn) SetDeadline(t time.Time) error {
 }
 
 // Implements net.Conn
-func (sc *SAMConn) SetReadDeadline(t time.Time) error {
+func (sc SAMConn) SetReadDeadline(t time.Time) error {
 	return sc.conn.SetReadDeadline(t)
 }
 
 // Implements net.Conn
-func (sc *SAMConn) SetWriteDeadline(t time.Time) error {
+func (sc SAMConn) SetWriteDeadline(t time.Time) error {
 	return sc.conn.SetWriteDeadline(t)
 }

--- a/SAMConn.go
+++ b/SAMConn.go
@@ -48,7 +48,7 @@ func (sc *SAMConn) remoteAddr() I2PAddr {
 }
 
 // Implements net.Conn
-func (sc *SAMConn) SetDeadline(t time.Time) error {
+func (sc SAMConn) SetDeadline(t time.Time) error {
 	return sc.conn.SetDeadline(t)
 }
 

--- a/SAMConn.go
+++ b/SAMConn.go
@@ -13,19 +13,19 @@ type SAMConn struct {
 }
 
 // Implements net.Conn
-func (sc *SAMConn) Read(buf []byte) (int, error) {
+func (sc SAMConn) Read(buf []byte) (int, error) {
 	n, err := sc.conn.Read(buf)
 	return n, err
 }
 
 // Implements net.Conn
-func (sc *SAMConn) Write(buf []byte) (int, error) {
+func (sc SAMConn) Write(buf []byte) (int, error) {
 	n, err := sc.conn.Write(buf)
 	return n, err
 }
 
 // Implements net.Conn
-func (sc *SAMConn) Close() error {
+func (sc SAMConn) Close() error {
 	return sc.conn.Close()
 }
 

--- a/datagram.go
+++ b/datagram.go
@@ -121,7 +121,7 @@ func (s *DatagramSession) Close() error {
 	return err2
 }
 
-// Returns the I2P destination of the DatagramSession. 
+// Returns the I2P destination of the DatagramSession.
 func (s *DatagramSession) LocalI2PAddr() I2PAddr {
 	return s.keys.Addr()
 }

--- a/datagram.go
+++ b/datagram.go
@@ -60,14 +60,14 @@ func (s *SAM) NewDatagramSession(id string, keys I2PKeys, options []string, udpP
 	return &DatagramSession{s.address, id, conn, udpconn, keys, rUDPAddr}, nil
 }
 
-func (s *DatagramSession) B32() string {
+func (s DatagramSession) B32() string {
 	return s.keys.Addr().Base32()
 }
 
 // Reads one datagram sent to the destination of the DatagramSession. Returns
 // the number of bytes read, from what address it was sent, or an error.
 // implements net.PacketConn
-func (s *DatagramSession) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
+func (s DatagramSession) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
 	// extra bytes to read the remote address of incomming datagram
 	buf := make([]byte, len(b)+4096)
 
@@ -104,7 +104,7 @@ func (s *DatagramSession) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
 // Sends one signed datagram to the destination specified. At the time of
 // writing, maximum size is 31 kilobyte, but this may change in the future.
 // Implements net.PacketConn.
-func (s *DatagramSession) WriteTo(b []byte, addr net.Addr) (n int, err error) {
+func (s DatagramSession) WriteTo(b []byte, addr net.Addr) (n int, err error) {
 	header := []byte("3.0 " + s.id + " " + addr.String() + "\n")
 	msg := append(header, b...)
 	n, err = s.udpconn.WriteToUDP(msg, s.rUDPAddr)
@@ -112,7 +112,7 @@ func (s *DatagramSession) WriteTo(b []byte, addr net.Addr) (n int, err error) {
 }
 
 // Closes the DatagramSession. Implements net.PacketConn
-func (s *DatagramSession) Close() error {
+func (s DatagramSession) Close() error {
 	err := s.conn.Close()
 	err2 := s.udpconn.Close()
 	if err != nil {
@@ -122,16 +122,16 @@ func (s *DatagramSession) Close() error {
 }
 
 // Returns the I2P destination of the DatagramSession.
-func (s *DatagramSession) LocalI2PAddr() I2PAddr {
+func (s DatagramSession) LocalI2PAddr() I2PAddr {
 	return s.keys.Addr()
 }
 
 // Implements net.PacketConn
-func (s *DatagramSession) LocalAddr() net.Addr {
+func (s DatagramSession) LocalAddr() net.Addr {
 	return s.LocalI2PAddr()
 }
 
-func (s *DatagramSession) Lookup(name string) (a net.Addr, err error) {
+func (s DatagramSession) Lookup(name string) (a net.Addr, err error) {
 	var sam *SAM
 	sam, err = NewSAM(s.samAddr)
 	if err == nil {
@@ -144,16 +144,16 @@ func (s *DatagramSession) Lookup(name string) (a net.Addr, err error) {
 // Sets read and write deadlines for the DatagramSession. Implements
 // net.PacketConn and does the same thing. Setting write deadlines for datagrams
 // is seldom done.
-func (s *DatagramSession) SetDeadline(t time.Time) error {
+func (s DatagramSession) SetDeadline(t time.Time) error {
 	return s.udpconn.SetDeadline(t)
 }
 
 // Sets read deadline for the DatagramSession. Implements net.PacketConn
-func (s *DatagramSession) SetReadDeadline(t time.Time) error {
+func (s DatagramSession) SetReadDeadline(t time.Time) error {
 	return s.udpconn.SetReadDeadline(t)
 }
 
 // Sets the write deadline for the DatagramSession. Implements net.Packetconn.
-func (s *DatagramSession) SetWriteDeadline(t time.Time) error {
+func (s DatagramSession) SetWriteDeadline(t time.Time) error {
 	return s.udpconn.SetWriteDeadline(t)
 }

--- a/sam3.go
+++ b/sam3.go
@@ -160,7 +160,7 @@ func (sam *SAM) Lookup(name string) (I2PAddr, error) {
 	}
 	s := bufio.NewScanner(bytes.NewReader(buf[13:n]))
 	s.Split(bufio.ScanWords)
-	
+
 	errStr := ""
 	for s.Scan() {
 		text := s.Text()

--- a/sam3_test.go
+++ b/sam3_test.go
@@ -13,7 +13,7 @@ func Test_Basic(t *testing.T) {
 	fmt.Println("\tAttaching to SAM at " + yoursam)
 	sam, err := NewSAM(yoursam)
 	if err != nil {
-		fmt.Println(err.Error)
+		fmt.Println(err.Error())
 		t.Fail()
 		return
 	}

--- a/stream.go
+++ b/stream.go
@@ -3,6 +3,7 @@ package sam3
 import (
 	"bufio"
 	"bytes"
+    "context"
 	"errors"
 	"io"
 	"net"
@@ -55,6 +56,11 @@ func (s *StreamSession) Lookup(name string) (I2PAddr, error) {
 		return addr, err
 	}
 	return I2PAddr(""), err
+}
+
+// context-aware dialer
+func (s *StreamSession) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
+    return nil, nil
 }
 
 // implement net.Dialer

--- a/stream.go
+++ b/stream.go
@@ -23,7 +23,7 @@ func (ss StreamSession) ID() string {
 	return ss.id
 }
 
-func (ss *StreamSession) Close() error {
+func (ss StreamSession) Close() error {
 	return ss.conn.Close()
 }
 
@@ -58,9 +58,9 @@ func (s *StreamSession) Lookup(name string) (I2PAddr, error) {
 	return I2PAddr(""), err
 }
 
-// context-aware dialer
+// context-aware dialer, eventually...
 func (s *StreamSession) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
-	return nil, nil
+	return s.Dial(n, addr)
 }
 
 // implement net.Dialer

--- a/stream.go
+++ b/stream.go
@@ -65,10 +65,10 @@ func (s *StreamSession) DialContext(ctx context.Context, n, addr string) (net.Co
 
 // context-aware dialer, eventually...
 func (s *StreamSession) DialContextI2P(ctx context.Context, n, addr string) (*SAMConn, error) {
-    i2paddr, err := NewI2PAddrFromString(addr)
-    if err != nil {
-        return nil, err
-    }
+	i2paddr, err := NewI2PAddrFromString(addr)
+	if err != nil {
+		return nil, err
+	}
 	return s.DialI2P(i2paddr)
 }
 

--- a/stream.go
+++ b/stream.go
@@ -3,7 +3,7 @@ package sam3
 import (
 	"bufio"
 	"bytes"
-    "context"
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -60,7 +60,7 @@ func (s *StreamSession) Lookup(name string) (I2PAddr, error) {
 
 // context-aware dialer
 func (s *StreamSession) DialContext(ctx context.Context, n, addr string) (net.Conn, error) {
-    return nil, nil
+	return nil, nil
 }
 
 // implement net.Dialer

--- a/stream.go
+++ b/stream.go
@@ -64,9 +64,12 @@ func (s *StreamSession) DialContext(ctx context.Context, n, addr string) (net.Co
 }
 
 // context-aware dialer, eventually...
-func (s *StreamSession) DialContextI2P(ctx context.Context, n, addr string) (SAMConn, error) {
-    x, err := s.Dial(n, addr)
-	return x.(SAMConn), err
+func (s *StreamSession) DialContextI2P(ctx context.Context, n, addr string) (*SAMConn, error) {
+    i2paddr, err := NewI2PAddrFromString(addr)
+    if err != nil {
+        return nil, err
+    }
+	return s.DialI2P(i2paddr)
 }
 
 // implement net.Dialer

--- a/stream.go
+++ b/stream.go
@@ -63,6 +63,12 @@ func (s *StreamSession) DialContext(ctx context.Context, n, addr string) (net.Co
 	return s.Dial(n, addr)
 }
 
+// context-aware dialer, eventually...
+func (s *StreamSession) DialContextI2P(ctx context.Context, n, addr string) (SAMConn, error) {
+    x, err := s.Dial(n, addr)
+	return x.(SAMConn), err
+}
+
 // implement net.Dialer
 func (s *StreamSession) Dial(n, addr string) (c net.Conn, err error) {
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -13,7 +13,7 @@ func Test_StreamingDial(t *testing.T) {
 	fmt.Println("Test_StreamingDial")
 	sam, err := NewSAM(yoursam)
 	if err != nil {
-		fmt.Println(err.Error)
+		fmt.Println(err.Error())
 		t.Fail()
 		return
 	}


### PR DESCRIPTION
So I've been working on making i2p work with libp2p and I keep running into the "x does not implement y, x has pointer reciever" and related errors. So I look all over Stack Overflow and everything I see confuses me more because I think "hey I definitely don't know everything, surely there must be a reason" but all indications are that I should just change the type in the function declarations from func (s *StructName) to func (s StructName). So finally I did it in my branch and ran the tests, and they passed. So I pushed it to my fork, updated everything I build which depends on my fork of sam3, it all still works, and now it all also works with libp2p transports(at least, without like 80% of the previously necessary modification). I don't want to break anybody else's application, but I don't think I'm going to? Is there some reason these need to be the way they are?